### PR TITLE
Add a Typeable Dict instance.

### DIFF
--- a/Data/Constraint.hs
+++ b/Data/Constraint.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ConstraintKinds #-}
@@ -55,11 +56,13 @@ import Control.Applicative
 import Data.Monoid
 import Data.Complex
 import Data.Ratio
+import Data.Typeable (Typeable)
 import GHC.Prim (Constraint)
 
 -- | Capture a dictionary for a given constraint
 data Dict :: Constraint -> * where
   Dict :: a => Dict a
+  deriving Typeable
 
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 707
 type role Dict nominal


### PR DESCRIPTION
This patch would avoid inserting an orphan instance in this other PR: https://github.com/haskell-distributed/rank1dynamic/pull/6

Please, advice on the needs for backwards compatibility. In my case it would work fine to just remove the instance for older versions of GHC.
