### PR TITLE
`withDict` continuation-style deconstructor for `Dict`

### DIFF
--- a/src/Data/Constraint.hs
+++ b/src/Data/Constraint.hs
@@ -52,6 +52,7 @@ module Data.Constraint
     Constraint
   -- * Dictionary
   , Dict(Dict)
+  , withDict
   -- * Entailment
   , (:-)(Sub)
   , (\\)
@@ -122,6 +123,16 @@ dictDataType = mkDataType "Data.Constraint.Dict" [dictConstr]
 deriving instance Eq (Dict a)
 deriving instance Ord (Dict a)
 deriving instance Show (Dict a)
+
+-- | From a 'Dict', takes a value in an environment where the instance
+-- witnessed by the 'Dict' is in scope, and evaluates it.
+--
+-- Essentially a deconstruction of a 'Dict' into its continuation-style
+-- form.
+--
+withDict :: Dict a -> (a => r) -> r
+withDict d r = case d of
+                 Dict -> r
 
 infixr 9 :-
 


### PR DESCRIPTION
This is a common pattern that I've found useful for everyday/practical usage of `Dict`.

Essentially lets you do things like:

~~~haskell
withDict d $ do
    blah
    blah
    blah
~~~

and

~~~haskell
withDict d (some expression of sorts)
withDict d $ some expression of sorts
~~~

instead of

~~~haskell
case d of
  Dict -> do
    blah
    blah
    blah
~~~

and

~~~haskell
case d of
  Dict -> some expression of sorts
~~~

At its surface, it's a "cosmetic" change, as one wouldn't have to explicitly pattern match on `Dict`, which saves an extra line and a level of indentation.

But, at a deeper level, it is a slick way of hiding the `Dict` constructor abstraction; one would be able to manipulate `Dict`s without ever using the `Dict` constructor, hiding away the constructor of the type as an implementation detail.  If the user is given a `Dict c`, they would only need to use `withDict` instead of explicitly pattern matching on a `Dict` constructor.