### PR TITLE
Generalize Bottom

### DIFF
--- a/src/Data/Constraint.hs
+++ b/src/Data/Constraint.hs
@@ -306,7 +306,7 @@ top = Sub Dict
 
 -- | 'Any' inhabits every kind, including 'Constraint' but is uninhabited, making it impossible to define an instance.
 class Prim.Any => Bottom where
-  no :: Dict a
+  no :: a
 
 -- |
 -- This demonstrates the law of classical logic <http://en.wikipedia.org/wiki/Principle_of_explosion "ex falso quodlibet">


### PR DESCRIPTION
Change the type of `no` from `Bottom => Dict a` to
`Bottom => a`. There is no reason to limit it to producing
dictionaries, and it's easier to understand the latter as
"given `Bottom`, you can have anything."