### PR TITLE
Swap first arguments of ‘defer’ to match ‘deferEither’

### DIFF
--- a/src/Data/Constraint/Deferrable.hs
+++ b/src/Data/Constraint/Deferrable.hs
@@ -43,7 +43,7 @@ class Deferrable (p :: Constraint) where
   deferEither :: proxy p -> (p => r) -> Either String r
 
 -- | Defer a constraint for later resolution in a context where we want to upgrade failure into an error
-defer :: forall proxy p r. Deferrable p => proxy p -> (p => r) -> r
+defer :: forall p proxy r. Deferrable p => proxy p -> (p => r) -> r
 defer _ r = either (throw . UnsatisfiedConstraint) id $ deferEither (Proxy :: Proxy p) r 
 
 deferred :: forall p. Deferrable p :- p

--- a/src/Data/Constraint/Deferrable.hs
+++ b/src/Data/Constraint/Deferrable.hs
@@ -40,10 +40,10 @@ instance Exception UnsatisfiedConstraint
 -- | Allow an attempt at resolution of a constraint at a later time
 class Deferrable (p :: Constraint) where
   -- | Resolve a 'Deferrable' constraint with observable failure.
-  deferEither :: proxy p -> (p => r) -> Either String r
+  deferEither :: forall r proxy. proxy p -> (p => r) -> Either String r
 
 -- | Defer a constraint for later resolution in a context where we want to upgrade failure into an error
-defer :: forall p proxy r. Deferrable p => proxy p -> (p => r) -> r
+defer :: forall p r proxy. Deferrable p => proxy p -> (p => r) -> r
 defer _ r = either (throw . UnsatisfiedConstraint) id $ deferEither (Proxy :: Proxy p) r 
 
 deferred :: forall p. Deferrable p :- p

--- a/src/Data/Constraint/Deferrable.hs
+++ b/src/Data/Constraint/Deferrable.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE ConstraintKinds #-}
@@ -5,6 +6,9 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE DeriveDataTypeable #-}
+#if __GLASGOW_HASKELL__ >= 800
+{-# LANGUAGE TypeApplications #-}
+#endif
 
 -----------------------------------------------------------------------------
 -- |
@@ -48,6 +52,15 @@ defer _ r = either (throw . UnsatisfiedConstraint) id $ deferEither (Proxy :: Pr
 
 deferred :: forall p. Deferrable p :- p
 deferred = Sub $ defer (Proxy :: Proxy p) Dict
+
+#if __GLASGOW_HASKELL__ >= 800
+-- | Functions that don't require a proxy argument.
+theDefer :: forall (p :: Constraint) r. Deferrable p => (p => r) -> r
+theDefer = defer @p Proxy
+
+theDeferEither :: forall (p :: Constraint) r. Deferrable p => (p => r) -> Either String r
+theDeferEither = deferEither @p Proxy
+#endif
 
 -- We use our own type equality rather than @Data.Type.Equality@ to allow building on GHC 7.6.
 data a :~: b where


### PR DESCRIPTION
Currently the parameters to `defer` and `deferEither` are in a different order:

```haskell
deferEither
  :: forall {p :: Constraint} {proxy :: Constraint -> *} {r}.
     Deferrable p =>
     proxy p -> (p => r) -> Either String r

defer
  :: forall {proxy :: Constraint -> *} {p :: Constraint} {r}.
     Deferrable p =>
     proxy p -> (p => r) -> r
```

With `TypeApplications` the order of `defer` should match `deferEither` which is more useful in my view