### PR TITLE
fix build failure on GHC-HEAD (importing Any)

### DIFF
--- a/src/Data/Constraint.hs
+++ b/src/Data/Constraint.hs
@@ -91,7 +91,7 @@ import GHC.Prim (Constraint)
 #else
 import GHC.Types (Constraint)
 #endif
-import qualified GHC.Base (Any)
+import qualified GHC.Exts (Any)
 
 
 -- | Values of type @'Dict' p@ capture a dictionary for a constraint of type @p@.
@@ -306,7 +306,7 @@ top :: a :- ()
 top = Sub Dict
 
 -- | 'Any' inhabits every kind, including 'Constraint' but is uninhabited, making it impossible to define an instance.
-class GHC.Base.Any => Bottom where
+class GHC.Exts.Any => Bottom where
   no :: Dict a
 
 -- |

--- a/src/Data/Constraint.hs
+++ b/src/Data/Constraint.hs
@@ -91,7 +91,8 @@ import GHC.Prim (Constraint)
 #else
 import GHC.Types (Constraint)
 #endif
-import qualified GHC.Prim as Prim
+import qualified GHC.Base (Any)
+
 
 -- | Values of type @'Dict' p@ capture a dictionary for a constraint of type @p@.
 --
@@ -305,7 +306,7 @@ top :: a :- ()
 top = Sub Dict
 
 -- | 'Any' inhabits every kind, including 'Constraint' but is uninhabited, making it impossible to define an instance.
-class Prim.Any => Bottom where
+class GHC.Base.Any => Bottom where
   no :: Dict a
 
 -- |


### PR DESCRIPTION
GHC-HEAD exports Any from GHC.Types instead of GHC.Prim as it was before.
See https://phabricator.haskell.org/D2049

Thankfully, GHC.Base seems to export Any in both versions.
So we import it from there.

Fixes #27