### PR TITLE
Fix compilation with GHC 8.1

### DIFF
--- a/src/Data/Constraint.hs
+++ b/src/Data/Constraint.hs
@@ -91,7 +91,7 @@ import GHC.Prim (Constraint)
 #else
 import GHC.Types (Constraint)
 #endif
-import qualified GHC.Prim as Prim
+import qualified GHC.Exts as Exts
 
 -- | Values of type @'Dict' p@ capture a dictionary for a constraint of type @p@.
 --
@@ -305,7 +305,7 @@ top :: a :- ()
 top = Sub Dict
 
 -- | 'Any' inhabits every kind, including 'Constraint' but is uninhabited, making it impossible to define an instance.
-class Prim.Any => Bottom where
+class Exts.Any => Bottom where
   no :: Dict a
 
 -- |


### PR DESCRIPTION


From https://ghc.haskell.org/trac/ghc/wiki/Migration/8.0#Kind-leveldefinitionsshuffledaround:
> If you're using various bits of magic from within GHC and importing from GHC.Prim (for example, for Constraint), you'll find that some definitions have moved around. There is a simple fix: import from GHC.Exts instead. That module re-exports all of GHC.Prim and a few other internal modules. This change is also backward-compatible.

This migration hint now also applies to `Any`, see https://ghc.haskell.org/trac/ghc/ticket/10886 ("Remove the magic from `Any`").