### PR TITLE
Use Any from GHC.Exts instead of GHC.Prim

### DIFF
--- a/src/Data/Constraint.hs
+++ b/src/Data/Constraint.hs
@@ -91,7 +91,7 @@ import GHC.Prim (Constraint)
 #else
 import GHC.Types (Constraint)
 #endif
-import qualified GHC.Prim as Prim
+import qualified GHC.Exts as Exts
 
 -- | Values of type @'Dict' p@ capture a dictionary for a constraint of type @p@.
 --
@@ -305,7 +305,7 @@ top :: a :- ()
 top = Sub Dict
 
 -- | 'Any' inhabits every kind, including 'Constraint' but is uninhabited, making it impossible to define an instance.
-class Prim.Any => Bottom where
+class Exts.Any => Bottom where
   no :: Dict a
 
 -- |


### PR DESCRIPTION
It is generally frowned upon to use GHC.Prim directly as it is highly
magical and therefore has minimal stability guarantees. In fact, Any
will be removed from GHC.Prim in 8.2.