### PR TITLE
Fix magic functions in Nat and Symbol

### DIFF
--- a/src/Data/Constraint/Nat.hs
+++ b/src/Data/Constraint/Nat.hs
@@ -54,10 +54,10 @@ type family Lcm :: Nat -> Nat -> Nat where
 
 type Divides n m = n ~ Gcd n m
 
-newtype Magic n r = Magic (KnownNat n => r)
+newtype Magic n = Magic (KnownNat n => Dict (KnownNat n))
 
 magic :: forall n m o. (Integer -> Integer -> Integer) -> (KnownNat n, KnownNat m) :- KnownNat o
-magic f = Sub $ unsafeCoerce (Magic id) (natVal (Proxy :: Proxy n) `f` natVal (Proxy :: Proxy m))
+magic f = Sub $ unsafeCoerce (Magic Dict) (natVal (Proxy :: Proxy n) `f` natVal (Proxy :: Proxy m))
 
 axiom :: forall a b. Dict (a ~ b)
 axiom = unsafeCoerce (Dict :: Dict (a ~ a))

--- a/src/Data/Constraint/Symbol.hs
+++ b/src/Data/Constraint/Symbol.hs
@@ -48,16 +48,16 @@ type family Length :: Symbol -> Nat where
 
 -- implementation details
 
-newtype Magic n r = Magic (KnownSymbol n => r)
+newtype Magic n = Magic (KnownSymbol n => Dict (KnownSymbol n))
 
 magicNSS :: forall n m o. (Int -> String -> String) -> (KnownNat n, KnownSymbol m) :- KnownSymbol o
-magicNSS f = Sub $ unsafeCoerce (Magic id) (fromIntegral (natVal (Proxy :: Proxy n)) `f` symbolVal (Proxy :: Proxy m))
+magicNSS f = Sub $ unsafeCoerce (Magic Dict) (fromIntegral (natVal (Proxy :: Proxy n)) `f` symbolVal (Proxy :: Proxy m))
 
 magicSSS :: forall n m o. (String -> String -> String) -> (KnownSymbol n, KnownSymbol m) :- KnownSymbol o
-magicSSS f = Sub $ unsafeCoerce (Magic id) (symbolVal (Proxy :: Proxy n) `f` symbolVal (Proxy :: Proxy m))
+magicSSS f = Sub $ unsafeCoerce (Magic Dict) (symbolVal (Proxy :: Proxy n) `f` symbolVal (Proxy :: Proxy m))
 
 magicSN :: forall a n. (String -> Int) -> KnownSymbol a :- KnownNat n
-magicSN f = Sub $ unsafeCoerce (Magic id) (toInteger (f (symbolVal (Proxy :: Proxy a))))
+magicSN f = Sub $ unsafeCoerce (Magic Dict) (toInteger (f (symbolVal (Proxy :: Proxy a))))
 
 axiom :: forall a b. Dict (a ~ b)
 axiom = unsafeCoerce (Dict :: Dict (a ~ a))


### PR DESCRIPTION
In [`magic`](https://github.com/ekmett/constraints/blob/0ed5c7cc8cd99e514ef5e995a7adaac9e2c10cdc/src/Data/Constraint/Nat.hs#L60), `Sub` expects a `Dict` but receives `id`, so things crash.

Here's a minimal test case exercising all 4 magic functions which now runs correctly.

    {-# LANGUAGE DataKinds #-}
    {-# LANGUAGE TypeApplications #-}
    {-# LANGUAGE TypeOperators #-}
    
    import Data.Constraint.Nat
    import Data.Constraint.Symbol
    import Data.Proxy
    import Data.Constraint
    import GHC.TypeLits
    
    main = do
      case gcdNat @15 @20 of
        Sub Dict -> print (natVal (Proxy :: Proxy (Gcd 15 20)))
      case appendSymbol @"a" @"b" of
        Sub Dict -> print (symbolVal (Proxy :: Proxy ("a" ++ "b")))
      case takeSymbol @3 @"abcde" of
        Sub Dict -> print (symbolVal (Proxy :: Proxy (Take 3 "abcde")))
      case lengthSymbol @"abcde" of
        Sub Dict -> print (natVal (Proxy :: Proxy (Length "abcde")))
