### PR TITLE
Add more Class and :=>

### DIFF
--- a/src/Data/Constraint.hs
+++ b/src/Data/Constraint.hs
@@ -84,6 +84,14 @@ import Data.Ratio
 import Data.Data
 import qualified GHC.Exts as Exts (Any)
 import GHC.Exts (Constraint)
+import Data.Bits (Bits)
+import Data.Functor.Identity (Identity)
+#if MIN_VERSION_base(4,8,0)
+import Numeric.Natural (Natural)
+#endif
+#if !MIN_VERSION_base(4,8,0)
+import Data.Word (Word)
+#endif
 
 -- | Values of type @'Dict' p@ capture a dictionary for a constraint of type @p@.
 --
@@ -406,6 +414,12 @@ instance (Eq a, Eq b) :=> Eq (a, b) where ins = Sub Dict
 instance (Eq a, Eq b) :=> Eq (Either a b) where ins = Sub Dict
 instance () :=> Eq (Dict a) where ins = Sub Dict
 instance () :=> Eq (a :- b) where ins = Sub Dict
+instance () :=> Eq Word where ins = Sub Dict
+instance Eq a :=> Eq (Identity a) where ins = Sub Dict
+#if MIN_VERSION_base(4,8,0)
+instance Eq a :=> Eq (Const a b) where ins = Sub Dict
+instance () :=> Eq Natural where ins = Sub Dict
+#endif
 
 -- Ord
 instance Class (Eq a) (Ord a) where cls = Sub Dict
@@ -423,6 +437,12 @@ instance (Ord a, Ord b) :=> Ord (Either a b) where ins = Sub Dict
 instance Integral a :=> Ord (Ratio a) where ins = Sub Dict
 instance () :=> Ord (Dict a) where ins = Sub Dict
 instance () :=> Ord (a :- b) where ins = Sub Dict
+instance () :=> Ord Word where ins = Sub Dict
+instance Ord a :=> Ord (Identity a) where ins = Sub Dict
+#if MIN_VERSION_base(4,8,0)
+instance Ord a :=> Ord (Const a b) where ins = Sub Dict
+instance () :=> Ord Natural where ins = Sub Dict
+#endif
 
 -- Show
 instance Class () (Show a) where cls = Sub Dict
@@ -438,6 +458,12 @@ instance (Show a, Show b) :=> Show (Either a b) where ins = Sub Dict
 instance (Integral a, Show a) :=> Show (Ratio a) where ins = Sub Dict
 instance () :=> Show (Dict a) where ins = Sub Dict
 instance () :=> Show (a :- b) where ins = Sub Dict
+instance () :=> Show Word where ins = Sub Dict
+instance Show a :=> Show (Identity a) where ins = Sub Dict
+#if MIN_VERSION_base(4,8,0)
+instance Show a :=> Show (Const a b) where ins = Sub Dict
+instance () :=> Show Natural where ins = Sub Dict
+#endif
 
 -- Read
 instance Class () (Read a) where cls = Sub Dict
@@ -451,6 +477,12 @@ instance Read a :=> Read (Maybe a) where ins = Sub Dict
 instance (Read a, Read b) :=> Read (a, b) where ins = Sub Dict
 instance (Read a, Read b) :=> Read (Either a b) where ins = Sub Dict
 instance (Integral a, Read a) :=> Read (Ratio a) where ins = Sub Dict
+instance () :=> Read Word where ins = Sub Dict
+instance Read a :=> Read (Identity a) where ins = Sub Dict
+#if MIN_VERSION_base(4,8,0)
+instance Read a :=> Read (Const a b) where ins = Sub Dict
+instance () :=> Read Natural where ins = Sub Dict
+#endif
 
 -- Enum
 instance Class () (Enum a) where cls = Sub Dict
@@ -463,6 +495,14 @@ instance () :=> Enum Integer where ins = Sub Dict
 instance () :=> Enum Float where ins = Sub Dict
 instance () :=> Enum Double where ins = Sub Dict
 instance Integral a :=> Enum (Ratio a) where ins = Sub Dict
+instance () :=> Enum Word where ins = Sub Dict
+#if MIN_VERSION_base(4,9,0)
+instance Enum a :=> Enum (Identity a) where ins = Sub Dict
+instance Enum a :=> Enum (Const a b) where ins = Sub Dict
+#endif
+#if MIN_VERSION_base(4,8,0)
+instance () :=> Enum Natural where ins = Sub Dict
+#endif
 
 -- Bounded
 instance Class () (Bounded a) where cls = Sub Dict
@@ -472,6 +512,11 @@ instance () :=> Bounded Bool where ins = Sub Dict
 instance () :=> Bounded Int where ins = Sub Dict
 instance () :=> Bounded Char where ins = Sub Dict
 instance (Bounded a, Bounded b) :=> Bounded (a,b) where ins = Sub Dict
+instance () :=> Bounded Word where ins = Sub Dict
+#if MIN_VERSION_base(4,9,0)
+instance Bounded a :=> Bounded (Identity a) where ins = Sub Dict
+instance Bounded a :=> Bounded (Const a b) where ins = Sub Dict
+#endif
 
 -- Num
 instance Class () (Num a) where cls = Sub Dict
@@ -481,6 +526,14 @@ instance () :=> Num Float where ins = Sub Dict
 instance () :=> Num Double where ins = Sub Dict
 instance RealFloat a :=> Num (Complex a) where ins = Sub Dict
 instance Integral a :=> Num (Ratio a) where ins = Sub Dict
+instance () :=> Num Word where ins = Sub Dict
+#if MIN_VERSION_base(4,9,0)
+instance Num a :=> Num (Identity a) where ins = Sub Dict
+instance Num a :=> Num (Const a b) where ins = Sub Dict
+#endif
+#if MIN_VERSION_base(4,8,0)
+instance () :=> Num Natural where ins = Sub Dict
+#endif
 
 -- Real
 instance Class (Num a, Ord a) (Real a) where cls = Sub Dict
@@ -489,11 +542,41 @@ instance () :=> Real Integer where ins = Sub Dict
 instance () :=> Real Float where ins = Sub Dict
 instance () :=> Real Double where ins = Sub Dict
 instance Integral a :=> Real (Ratio a) where ins = Sub Dict
+instance () :=> Real Word where ins = Sub Dict
+#if MIN_VERSION_base(4,9,0)
+instance Real a :=> Real (Identity a) where ins = Sub Dict
+instance Real a :=> Real (Const a b) where ins = Sub Dict
+#endif
+#if MIN_VERSION_base(4,8,0)
+instance () :=> Real Natural where ins = Sub Dict
+#endif
 
 -- Integral
 instance Class (Real a, Enum a) (Integral a) where cls = Sub Dict
 instance () :=> Integral Int where ins = Sub Dict
 instance () :=> Integral Integer where ins = Sub Dict
+instance () :=> Integral Word where ins = Sub Dict
+#if MIN_VERSION_base(4,9,0)
+instance Integral a :=> Integral (Identity a) where ins = Sub Dict
+instance Integral a :=> Integral (Const a b) where ins = Sub Dict
+#endif
+#if MIN_VERSION_base(4,8,0)
+instance () :=> Integral Natural where ins = Sub Dict
+#endif
+
+-- Bits
+instance Class (Eq a) (Bits a) where cls = Sub Dict
+instance () :=> Bits Bool where ins = Sub Dict
+instance () :=> Bits Int where ins = Sub Dict
+instance () :=> Bits Integer where ins = Sub Dict
+instance () :=> Bits Word where ins = Sub Dict
+#if MIN_VERSION_base(4,9,0)
+instance Bits a :=> Bits (Identity a) where ins = Sub Dict
+instance Bits a :=> Bits (Const a b) where ins = Sub Dict
+#endif
+#if MIN_VERSION_base(4,8,0)
+instance () :=> Bits Natural where ins = Sub Dict
+#endif
 
 -- Fractional
 instance Class (Num a) (Fractional a) where cls = Sub Dict
@@ -501,23 +584,39 @@ instance () :=> Fractional Float where ins = Sub Dict
 instance () :=> Fractional Double where ins = Sub Dict
 instance RealFloat a :=> Fractional (Complex a) where ins = Sub Dict
 instance Integral a :=> Fractional (Ratio a) where ins = Sub Dict
+#if MIN_VERSION_base(4,9,0)
+instance Fractional a :=> Fractional (Identity a) where ins = Sub Dict
+instance Fractional a :=> Fractional (Const a b) where ins = Sub Dict
+#endif
 
 -- Floating
 instance Class (Fractional a) (Floating a) where cls = Sub Dict
 instance () :=> Floating Float where ins = Sub Dict
 instance () :=> Floating Double where ins = Sub Dict
 instance RealFloat a :=> Floating (Complex a) where ins = Sub Dict
+#if MIN_VERSION_base(4,9,0)
+instance Floating a :=> Floating (Identity a) where ins = Sub Dict
+instance Floating a :=> Floating (Const a b) where ins = Sub Dict
+#endif
 
 -- RealFrac
 instance Class (Real a, Fractional a) (RealFrac a) where cls = Sub Dict
 instance () :=> RealFrac Float where ins = Sub Dict
 instance () :=> RealFrac Double where ins = Sub Dict
 instance Integral a :=> RealFrac (Ratio a) where ins = Sub Dict
+#if MIN_VERSION_base(4,9,0)
+instance RealFrac a :=> RealFrac (Identity a) where ins = Sub Dict
+instance RealFrac a :=> RealFrac (Const a b) where ins = Sub Dict
+#endif
 
 -- RealFloat
 instance Class (RealFrac a, Floating a) (RealFloat a) where cls = Sub Dict
 instance () :=> RealFloat Float where ins = Sub Dict
 instance () :=> RealFloat Double where ins = Sub Dict
+#if MIN_VERSION_base(4,9,0)
+instance RealFloat a :=> RealFloat (Identity a) where ins = Sub Dict
+instance RealFloat a :=> RealFloat (Const a b) where ins = Sub Dict
+#endif
 
 -- Monoid
 instance Class () (Monoid a) where cls = Sub Dict
@@ -526,6 +625,13 @@ instance () :=> Monoid Ordering where ins = Sub Dict
 instance () :=> Monoid [a] where ins = Sub Dict
 instance Monoid a :=> Monoid (Maybe a) where ins = Sub Dict
 instance (Monoid a, Monoid b) :=> Monoid (a, b) where ins = Sub Dict
+instance Monoid a :=> Monoid (Const a b) where ins = Sub Dict
+#if MIN_VERSION_base(4,9,0)
+instance Monoid a :=> Monoid (Identity a) where ins = Sub Dict
+#endif
+#if MIN_VERSION_base(4,9,0)
+instance Monoid a :=> Monoid (IO a) where ins = Sub Dict
+#endif
 
 -- Functor
 instance Class () (Functor f) where cls = Sub Dict
@@ -536,6 +642,8 @@ instance () :=> Functor ((->) a) where ins = Sub Dict
 instance () :=> Functor ((,) a) where ins = Sub Dict
 instance () :=> Functor IO where ins = Sub Dict
 instance Monad m :=> Functor (WrappedMonad m) where ins = Sub Dict
+instance () :=> Functor Identity where ins = Sub Dict
+instance () :=> Functor (Const a) where ins = Sub Dict
 
 -- Applicative
 instance Class (Functor f) (Applicative f) where cls = Sub Dict
@@ -545,6 +653,7 @@ instance () :=> Applicative (Either a) where ins = Sub Dict
 instance () :=> Applicative ((->)a) where ins = Sub Dict
 instance () :=> Applicative IO where ins = Sub Dict
 instance Monoid a :=> Applicative ((,)a) where ins = Sub Dict
+instance Monoid a :=> Applicative (Const a) where ins = Sub Dict
 instance Monad m :=> Applicative (WrappedMonad m) where ins = Sub Dict
 
 -- Alternative
@@ -554,14 +663,23 @@ instance () :=> Alternative Maybe where ins = Sub Dict
 instance MonadPlus m :=> Alternative (WrappedMonad m) where ins = Sub Dict
 
 -- Monad
+#if MIN_VERSION_base(4,8,0)
+instance Class (Applicative f) (Monad f) where cls = Sub Dict
+#else
 instance Class () (Monad f) where cls = Sub Dict
+#endif
 instance () :=> Monad [] where ins = Sub Dict
 instance () :=> Monad ((->) a) where ins = Sub Dict
 instance () :=> Monad (Either a) where ins = Sub Dict
 instance () :=> Monad IO where ins = Sub Dict
+instance () :=> Monad Identity where ins = Sub Dict
 
 -- MonadPlus
+#if MIN_VERSION_base(4,8,0)
+instance Class (Monad f, Alternative f) (MonadPlus f) where cls = Sub Dict
+#else
 instance Class (Monad f) (MonadPlus f) where cls = Sub Dict
+#endif
 instance () :=> MonadPlus [] where ins = Sub Dict
 instance () :=> MonadPlus Maybe where ins = Sub Dict
 


### PR DESCRIPTION
* Update `Class` for AMP.

* Add `Bits`, `Natural`, and `Word`. There are still a lot of
`Int` and `Word` variants missing.

Fixes #48