### PR TITLE
Adapt to the Semigroup-Monoid Proposal

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,5 +1,11 @@
 next
 ----
+* Adapt to the `Semigroup`–`Monoid` Proposal (introduced in `base-4.11`):
+  * Add a `Semigroup` instance for `Dict`
+  * Add the appropriate `(:=>)` instances involving `Semigroup`, and change the
+    `Class () (Monoid a)` instance to `Class (Semigroup a) (Monoid a)` when
+    `base` is recent enough
+  * Add the appropriate `Lifting(2)` instances involving `Semigroup`
 * Fix the type signature of `maxCommutes`
 * Add `NFData` instances for `Dict` and `(:-)`
 

--- a/constraints.cabal
+++ b/constraints.cabal
@@ -48,6 +48,7 @@ library
     ghc-prim,
     hashable >= 1.2 && < 1.3,
     mtl >= 2 && < 2.3,
+    semigroups >= 0.11 && < 0.19,
     transformers >= 0.2 && < 0.6,
     transformers-compat >= 0.4 && < 1
 

--- a/src/Data/Constraint.hs
+++ b/src/Data/Constraint.hs
@@ -82,6 +82,7 @@ import Data.Monoid
 #endif
 import Data.Complex
 import Data.Ratio
+import Data.Semigroup
 import Data.Data
 import qualified GHC.Exts as Exts (Any)
 import GHC.Exts (Constraint)
@@ -625,8 +626,27 @@ instance RealFloat a :=> RealFloat (Identity a) where ins = Sub Dict
 instance RealFloat a :=> RealFloat (Const a b) where ins = Sub Dict
 #endif
 
+-- Semigroup
+instance Class () (Semigroup a) where cls = Sub Dict
+instance () :=> Semigroup () where ins = Sub Dict
+instance () :=> Semigroup Ordering where ins = Sub Dict
+instance () :=> Semigroup [a] where ins = Sub Dict
+instance Semigroup a :=> Semigroup (Maybe a) where ins = Sub Dict
+instance (Semigroup a, Semigroup b) :=> Semigroup (a, b) where ins = Sub Dict
+instance Semigroup a :=> Semigroup (Const a b) where ins = Sub Dict
+#if MIN_VERSION_base(4,9,0)
+instance Semigroup a :=> Semigroup (Identity a) where ins = Sub Dict
+#endif
+#if MIN_VERSION_base(4,10,0)
+instance Semigroup a :=> Semigroup (IO a) where ins = Sub Dict
+#endif
+
 -- Monoid
+#if MIN_VERSION_base(4,11,0)
+instance Class (Semigroup a) (Monoid a) where cls = Sub Dict
+#else
 instance Class () (Monoid a) where cls = Sub Dict
+#endif
 instance () :=> Monoid () where ins = Sub Dict
 instance () :=> Monoid Ordering where ins = Sub Dict
 instance () :=> Monoid [a] where ins = Sub Dict
@@ -635,8 +655,6 @@ instance (Monoid a, Monoid b) :=> Monoid (a, b) where ins = Sub Dict
 instance Monoid a :=> Monoid (Const a b) where ins = Sub Dict
 #if MIN_VERSION_base(4,9,0)
 instance Monoid a :=> Monoid (Identity a) where ins = Sub Dict
-#endif
-#if MIN_VERSION_base(4,9,0)
 instance Monoid a :=> Monoid (IO a) where ins = Sub Dict
 #endif
 
@@ -707,7 +725,13 @@ instance a => Bounded (Dict a) where
 instance a :=> Read (Dict a) where ins = Sub Dict
 deriving instance a => Read (Dict a)
 
+instance () :=> Semigroup (Dict a) where ins = Sub Dict
+instance Semigroup (Dict a) where
+  Dict <> Dict = Dict
+
 instance a :=> Monoid (Dict a) where ins = Sub Dict
 instance a => Monoid (Dict a) where
-  mappend Dict Dict = Dict
+#if !(MIN_VERSION_base(4,11,0))
+  mappend = (<>)
+#endif
   mempty = Dict

--- a/src/Data/Constraint.hs
+++ b/src/Data/Constraint.hs
@@ -77,9 +77,6 @@ import Control.Applicative
 import Control.Category
 import Control.DeepSeq
 import Control.Monad
-#if __GLASGOW_HASKELL__ < 710
-import Data.Monoid
-#endif
 import Data.Complex
 import Data.Ratio
 import Data.Semigroup

--- a/src/Data/Constraint/Lifting.hs
+++ b/src/Data/Constraint/Lifting.hs
@@ -9,7 +9,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PolyKinds #-}
 {-# OPTIONS_GHC -fno-warn-deprecations #-}
-module Data.Constraint.Lifting 
+module Data.Constraint.Lifting
   ( Lifting(..)
   , Lifting2(..)
   ) where
@@ -54,6 +54,9 @@ import Data.Hashable
 import Data.Monoid
 #endif
 import Data.Ratio
+#if !(MIN_VERSION_base(4,11,0))
+import Data.Semigroup
+#endif
 #if __GLASGOW_HASKELL__ < 710
 import Data.Traversable
 #endif
@@ -77,6 +80,7 @@ instance Lifting Read Maybe where lifting = Sub Dict
 instance Lifting Hashable Maybe where lifting = Sub Dict
 instance Lifting Binary Maybe where lifting = Sub Dict
 instance Lifting NFData Maybe where lifting = Sub Dict
+instance Lifting Semigroup Maybe where lifting = Sub Dict
 instance Lifting Monoid Maybe where lifting = Sub Dict
 
 instance Lifting Eq Ratio where lifting = Sub Dict
@@ -85,7 +89,7 @@ instance Lifting Eq Ratio where lifting = Sub Dict
 instance Lifting Eq Complex where lifting = Sub Dict
 instance Lifting Read Complex where lifting = Sub Dict
 instance Lifting Show Complex where lifting = Sub Dict
-
+instance Lifting Semigroup ((->) a) where lifting = Sub Dict
 instance Lifting Monoid ((->) a) where lifting = Sub Dict
 
 instance Eq a => Lifting Eq (Either a) where lifting = Sub Dict
@@ -103,6 +107,7 @@ instance Read a => Lifting Read ((,) a) where lifting = Sub Dict
 instance Hashable a => Lifting Hashable ((,) a) where lifting = Sub Dict
 instance Binary a => Lifting Binary ((,) a) where lifting = Sub Dict
 instance NFData a => Lifting NFData ((,) a) where lifting = Sub Dict
+instance Semigroup a => Lifting Semigroup ((,) a) where lifting = Sub Dict
 instance Monoid a => Lifting Monoid ((,) a) where lifting = Sub Dict
 instance Bounded a => Lifting Bounded ((,) a) where lifting = Sub Dict
 instance Ix a => Lifting Ix ((,) a) where lifting = Sub Dict
@@ -434,6 +439,7 @@ instance Lifting2 Read (,) where lifting2 = Sub Dict
 instance Lifting2 Hashable (,) where lifting2 = Sub Dict
 instance Lifting2 Binary (,) where lifting2 = Sub Dict
 instance Lifting2 NFData (,) where lifting2 = Sub Dict
+instance Lifting2 Semigroup (,) where lifting2 = Sub Dict
 instance Lifting2 Monoid (,) where lifting2 = Sub Dict
 instance Lifting2 Bounded (,) where lifting2 = Sub Dict
 instance Lifting2 Ix (,) where lifting2 = Sub Dict


### PR DESCRIPTION
In the next version of `base` (4.11), `Semigroup` will be a superclass of `Monoid`. This PR updates `constraints` accordingly.