### PR TITLE
Reexport Div/Mod from GHC.TypeLits (introduced in GHC 8.4)

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -6,6 +6,8 @@ next
     `Class () (Monoid a)` instance to `Class (Semigroup a) (Monoid a)` when
     `base` is recent enough
   * Add the appropriate `Lifting(2)` instances involving `Semigroup`
+* `Data.Constraint.Nat` now reexports the `Div` and `Mod` type families from
+  `GHC.TypeLits` on `base-4.11` or later
 * Fix the type signature of `maxCommutes`
 * Add `NFData` instances for `Dict` and `(:-)`
 

--- a/src/Data/Constraint/Nat.hs
+++ b/src/Data/Constraint/Nat.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
@@ -49,10 +50,12 @@ type family Min (m::Nat) (n::Nat) :: Nat where
     Min m m = m
 type family Max (m::Nat) (n::Nat) :: Nat where
     Max m m = m
+#if !(MIN_VERSION_base(4,11,0))
 type family Div (m::Nat) (n::Nat) :: Nat where
     Div m 1 = m
 type family Mod (m::Nat) (n::Nat) :: Nat where
     Mod 0 m = 0
+#endif
 type family Gcd (m::Nat) (n::Nat) :: Nat where
     Gcd m m = m
 type family Lcm (m::Nat) (n::Nat) :: Nat where


### PR DESCRIPTION
`base-4.11`+ (GHC 8.4+) introduced wired-in `Div` and `Mod` type families to `GHC.TypeLits`. Alas, these clash with the ones defined locally in `Data.Constraint.Nat`, so this PR takes the approach of simply reexporting the ones from `GHC.TypeLits` when a recent-enough `base` is used.