### PR TITLE
Export `no` (a method of Bottom)

### DIFF
--- a/src/Data/Constraint.hs
+++ b/src/Data/Constraint.hs
@@ -64,7 +64,7 @@ module Data.Constraint
   , strengthen1, strengthen2
   , (&&&), (***)
   , trans, refl
-  , Bottom
+  , Bottom(no)
   , top, bottom
   -- * Dict is fully faithful
   , mapDict


### PR DESCRIPTION
I think `no :: Bottom => a` is sometimes useful like `absurd`.