### PR TITLE
Add axioms about plus and minus

### DIFF
--- a/src/Data/Constraint/Nat.hs
+++ b/src/Data/Constraint/Nat.hs
@@ -152,6 +152,15 @@ leZero = Sub axiom
 zeroLe :: forall a. Dict (0 <= a)
 zeroLe = Dict
 
+plusMinusInverse1 :: forall n m. Dict (((m + n) - n) ~ m)
+plusMinusInverse1 = axiom
+
+plusMinusInverse2 :: forall n m. (m <= n) :- (((m + n) - m) ~ n)
+plusMinusInverse2 = Sub axiom
+
+plusMinusInverse3 :: forall n m. (n <= m) :- (((m - n) + n) ~ m)
+plusMinusInverse3 = Sub axiom
+
 plusMonotone1 :: forall a b c. (a <= b) :- (a + c <= b + c)
 plusMonotone1 = Sub axiom
 


### PR DESCRIPTION
Add axioms for plus and minus of natural numbers being inverse (some requiring a <= relationship between some of then numbers).

These three constraints were pulled from https://github.com/agda/agda-stdlib/blob/master/src/Data/Nat/Properties.agda#L1011-L1029