### PR TITLE
Complete definitions of Min and Max

### DIFF
--- a/src/Data/Constraint/Nat.hs
+++ b/src/Data/Constraint/Nat.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE UndecidableInstances #-}
 #if __GLASGOW_HASKELL__ >= 805
 {-# LANGUAGE NoStarIsType #-}
 #endif
@@ -47,13 +48,14 @@ module Data.Constraint.Nat
 
 import Data.Constraint
 import Data.Proxy
+import Data.Type.Bool
 import GHC.TypeLits
 import Unsafe.Coerce
 
 type family Min (m::Nat) (n::Nat) :: Nat where
-    Min m m = m
+    Min m n = If (n <=? m) n m
 type family Max (m::Nat) (n::Nat) :: Nat where
-    Max m m = m
+    Max m n = If (n <=? m) m n
 #if !(MIN_VERSION_base(4,11,0))
 type family Div (m::Nat) (n::Nat) :: Nat where
     Div m 1 = m
@@ -148,10 +150,10 @@ timesOne :: forall n. Dict ((n * 1) ~ n)
 timesOne = Dict
 
 minZero :: forall n. Dict (Min n 0 ~ 0)
-minZero = axiom
+minZero = Dict
 
 maxZero :: forall n. Dict (Max n 0 ~ n)
-maxZero = axiom
+maxZero = Dict
 
 powZero :: forall n. Dict ((n ^ 0) ~ 1)
 powZero = Dict


### PR DESCRIPTION
This patch completes definitions of type families `Min` and `Max`, making GHC able to reason about them better. Before:

```
> :kind! Min 5 6
Min 5 6 :: GHC.Types.Nat
= Min 5 6
> :kind! Max 5 6
Max 5 6 :: GHC.Types.Nat
= Max 5 6
```

Now:

```
> :kind! Min 5 6
Min 5 6 :: GHC.Types.Nat
= 5
> :kind! Max 5 6
Max 5 6 :: GHC.Types.Nat
= 6
```

As a side effect, GHC becomes able to deduce `minZero` and `maxZero` on its own, without `axiom`.