### PR TITLE
Support semigroups-0.19

### DIFF
--- a/constraints.cabal
+++ b/constraints.cabal
@@ -54,7 +54,7 @@ library
     ghc-prim,
     hashable >= 1.2 && < 1.3,
     mtl >= 2.1.2 && < 2.3,
-    semigroups >= 0.17 && < 0.19,
+    semigroups >= 0.17 && < 0.20,
     transformers >= 0.3.0.0 && < 0.6,
     transformers-compat >= 0.5 && < 1
 


### PR DESCRIPTION
Pardon an automatically-posted pull request; this is a part of [Operation Vanguard](https://github.com/haskell-vanguard/haskell-vanguard). Note that this does not guarantee that tests and benchmarks are buildable.