### PR TITLE
Depend on type-equality to use (:~~:) on GHC 8.0

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,9 @@
+next [????.??.??]
+-----------------
+* Depend on the `type-equality` compatibility library so that `(:~~:)` may be
+  used when compiling this library with GHC 8.0. This avoids having to redefine
+  `(:~~:)` directly in the internals of `constraints` itself.
+
 0.11.1 [2019.08.27]
 -------------------
 * Make `Data.Constraint.Deferrable.UnsatisfiedConstraint` a newtype.

--- a/constraints.cabal
+++ b/constraints.cabal
@@ -56,7 +56,8 @@ library
     mtl >= 2.1.2 && < 2.3,
     semigroups >= 0.17 && < 0.20,
     transformers >= 0.3.0.0 && < 0.6,
-    transformers-compat >= 0.5 && < 1
+    transformers-compat >= 0.5 && < 1,
+    type-equality >= 1 && < 2
 
   exposed-modules:
     Data.Constraint

--- a/src/Data/Constraint.hs
+++ b/src/Data/Constraint.hs
@@ -105,8 +105,11 @@ import Data.Word (Word)
 #endif
 import Data.Coerce (Coercible)
 import Data.Type.Coercion(Coercion(..))
-#if MIN_VERSION_base(4,10,0)
+#if MIN_VERSION_base(4,9,0)
 import Data.Type.Equality (type (~~))
+import qualified Data.Type.Equality.Hetero as Hetero
+#endif
+#if MIN_VERSION_base(4,10,0)
 import Type.Reflection (TypeRep, typeRepKind, withTypeable)
 #endif
 
@@ -170,10 +173,12 @@ instance HasDict (Coercible a b) (Coercion a b) where
 instance HasDict (a ~ b) (a :~: b) where
   evidence Refl = Dict
 
-#if MIN_VERSION_base(4,10,0)
-instance HasDict (a ~~ b) (a :~~: b) where
-  evidence HRefl = Dict
+#if MIN_VERSION_base(4,9,0)
+instance HasDict (a ~~ b) (a Hetero.:~~: b) where
+  evidence Hetero.HRefl = Dict
+#endif
 
+#if MIN_VERSION_base(4,10,0)
 instance HasDict (Typeable k, Typeable a) (TypeRep (a :: k)) where
   evidence tr = withTypeable tr $ withTypeable (typeRepKind tr) Dict
 #endif

--- a/src/Data/Constraint/Deferrable.hs
+++ b/src/Data/Constraint/Deferrable.hs
@@ -49,10 +49,7 @@ import Data.Type.Equality ((:~:)(Refl))
 
 #if __GLASGOW_HASKELL__ >= 800
 import GHC.Types (type (~~))
-#endif
-
-#if __GLASGOW_HASKELL__ >= 801
-import Data.Type.Equality ((:~~:)(HRefl))
+import Data.Type.Equality.Hetero ((:~~:)(HRefl))
 #endif
 
 newtype UnsatisfiedConstraint = UnsatisfiedConstraint String
@@ -84,16 +81,6 @@ defer_ r = defer @p Proxy r
 -- Only available on GHC 8.0 or later.
 deferEither_ :: forall p r. Deferrable p => (p => r) -> Either String r
 deferEither_ r = deferEither @p Proxy r
-#endif
-
-#if __GLASGOW_HASKELL__ >= 800 && __GLASGOW_HASKELL__ < 801
--- | Kind heterogeneous propositional equality. Like '(:~:)', @a :~~: b@ is
--- inhabited by a terminating value if and only if @a@ is the same type as @b@.
---
--- Only available on GHC 8.0 or later.
-data (a :: i) :~~: (b :: j) where
-  HRefl :: a :~~: a
-    deriving Typeable
 #endif
 
 showTypeRep :: Typeable t => Proxy t -> String


### PR DESCRIPTION
Depend on the `type-equality` compatibility library so that `(:~~:)` may be used when compiling this library with GHC 8.0. This avoids having to redefine `(:~~:)` directly in the internals of `constraints` itself.