### PR TITLE
Add Haddock for Unicode alias

### DIFF
--- a/src/Data/Constraint.hs
+++ b/src/Data/Constraint.hs
@@ -208,6 +208,7 @@ r \\ d = withDict d r
 infixr 9 :-
 infixr 9 ⊢
 
+-- | Type entailment, as written with a single character.
 type (⊢) = (:-)
 
 -- | This is the type of entailment.


### PR DESCRIPTION
In non-Unicode locales, Haskell's character set handling means that if Haddock tries to print the list of undocumented symbols (even quietly as in `cabal new-build`) and comes across any unknown characters, the entire thing crashes.  This makes it go smoothly.