### PR TITLE
Depend on semigroups only on GHC < 8.0

### DIFF
--- a/constraints.cabal
+++ b/constraints.cabal
@@ -55,10 +55,11 @@ library
     ghc-prim,
     hashable >= 1.2 && < 1.4,
     mtl >= 2.1.2 && < 2.3,
-    semigroups >= 0.17 && < 0.20,
     transformers >= 0.3.0.0 && < 0.6,
     transformers-compat >= 0.5 && < 1,
     type-equality >= 1 && < 2
+  if impl(ghc < 8.0)
+    build-depends: semigroups >= 0.17 && < 0.20
 
   exposed-modules:
     Data.Constraint


### PR DESCRIPTION
They are not needed on newer GHC.