### PR TITLE
Guard `mtl`-related instances for `ErrorT`/`ListT` with appropriate CPP

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,8 @@
+next [????.??.??]
+-----------------
+* Correct the CPP introduced in `constraints-0.13.3` such that it works when
+  building with `mtl-2.3.*` or later combined with `transformers < 0.6`.
+
 0.13.3 [2022.01.31]
 -------------------
 * Allow building with `transformers-0.6.*` and `mtl-2.3.*`.

--- a/src/Data/Constraint/Lifting.hs
+++ b/src/Data/Constraint/Lifting.hs
@@ -399,10 +399,12 @@ instance (Show e, Show1 m) => Lifting Show (ErrorT e m) where lifting = Sub Dict
 instance (Eq e, Eq1 m) => Lifting Eq (ErrorT e m) where lifting = Sub Dict
 instance (Ord e, Ord1 m) => Lifting Ord (ErrorT e m) where lifting = Sub Dict
 instance (Read e, Read1 m) => Lifting Read (ErrorT e m) where lifting = Sub Dict
+# if !(MIN_VERSION_mtl(2,3,0))
 instance Error e => Lifting MonadCont (ErrorT e) where lifting = Sub Dict
 instance Error e => Lifting (MonadRWS r w s) (ErrorT e) where lifting = Sub Dict
 instance Error e => Lifting (MonadReader r) (ErrorT e) where lifting = Sub Dict
 instance Error e => Lifting (MonadState s) (ErrorT e) where lifting = Sub Dict
+# endif
 
 instance Lifting Functor ListT where lifting = Sub Dict
 instance Lifting Applicative ListT where lifting = Sub Dict
@@ -421,10 +423,12 @@ instance Show1 m => Lifting Show (ListT m) where lifting = Sub Dict
 instance Read1 m => Lifting Read (ListT m) where lifting = Sub Dict
 instance Ord1 m => Lifting Ord (ListT m) where lifting = Sub Dict
 instance Eq1 m => Lifting Eq (ListT m) where lifting = Sub Dict
+# if !(MIN_VERSION_mtl(2,3,0))
 instance Lifting MonadCont ListT where lifting = Sub Dict
 instance Lifting (MonadError e) ListT where lifting = Sub Dict
 instance Lifting (MonadReader r) ListT where lifting = Sub Dict
 instance Lifting (MonadState s) ListT where lifting = Sub Dict
+# endif
 #endif
 
 class Lifting2 p f where


### PR DESCRIPTION
Previously, all instances involving `ErrorT` and `ListT` were guarded with `!MIN_VERSION_transformers(0,6,0)`. This turns out not to be enough, however, as the instances involving classes from `mtl` also need to be guarded with `!MIN_VERSION_mtl(2,3,0)`. This is because while `mtl-2.3.*` does build with `transformers-0.5.*`, it does not provide instances for `ErrorT` or `ListT`, which could result in the build failures observed in #115.

Fixes #115.