### PR TITLE
Implement `Data.Constraint.{Nat,Symbol}`'s magic using `withKnown{Nat,Symbol}` when possible

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -8,6 +8,8 @@
 * Remove `Lifting` instances for `ErrorT` and `ListT`, which were removed
   in `transformers-0.6.*`.
 * Add `unsafeAxiom` to `Data.Constraint.Unsafe`.
+* Add `unsafeSNat` and `unsafeSSymbol` to `Data.Constraint.Unsafe` when building
+  with `base-4.18` (GHC 9.6) or later.
 
 0.13.4 [2022.05.19]
 -------------------

--- a/src/Data/Constraint/Unsafe.hs
+++ b/src/Data/Constraint/Unsafe.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE Unsafe #-}
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 
 -- |
@@ -24,11 +25,22 @@ module Data.Constraint.Unsafe
   , unsafeCoerceConstraint
   , unsafeDerive
   , unsafeUnderive
+
+#if MIN_VERSION_base(4,18,0)
+    -- * Unsafely creating @GHC.TypeLits@ singleton values
+  , unsafeSNat
+  , unsafeSSymbol
+#endif
   ) where
 
 import Data.Coerce
 import Data.Constraint
 import Unsafe.Coerce
+
+#if MIN_VERSION_base(4,18,0)
+import GHC.TypeLits (SNat, SSymbol)
+import Numeric.Natural (Natural)
+#endif
 
 -- | Unsafely create a dictionary for any constraint.
 unsafeAxiom :: Dict c
@@ -46,3 +58,37 @@ unsafeDerive _ = unsafeCoerceConstraint
 unsafeUnderive :: Coercible n o => (o -> n) -> t n :- t o
 unsafeUnderive _ = unsafeCoerceConstraint
 
+#if MIN_VERSION_base(4,18,0)
+-- NB: if https://gitlab.haskell.org/ghc/ghc/-/issues/23478 were implemented,
+-- then we could avoid using 'unsafeCoerce' in the definitions below.
+
+-- | Unsafely create an 'SNat' value directly from a 'Natural'. Use this
+-- function with care:
+--
+-- * The 'Natural' value must match the 'Nat' @n@ encoded in the return type
+--   @'SNat' n@.
+--
+-- * Be wary of using this function to create multiple values of type
+--   @'SNat' T@, where @T@ is a type family that does not reduce (e.g.,
+--   @Any@ from "GHC.Exts"). If you do, GHC is liable to optimize away one of
+--   the values and replace it with the other during a common subexpression
+--   elimination pass. If the two values have different underlying 'Natural'
+--   values, this could be disastrous.
+unsafeSNat :: Natural -> SNat n
+unsafeSNat = unsafeCoerce
+
+-- | Unsafely create an 'SSymbol' value directly from a 'String'. Use this
+-- function with care:
+--
+-- * The 'String' value must match the 'Symbol' @s@ encoded in the return type
+--   @'SSymbol' s@.
+--
+-- * Be wary of using this function to create multiple values of type
+--   @'SSymbol' T@, where @T@ is a type family that does not reduce (e.g.,
+--   @Any@ from "GHC.Exts"). If you do, GHC is liable to optimize away one of
+--   the values and replace it with the other during a common subexpression
+--   elimination pass. If the two values have different underlying 'String'
+--   values, this could be disastrous.
+unsafeSSymbol :: String -> SSymbol s
+unsafeSSymbol = unsafeCoerce
+#endif


### PR DESCRIPTION
This reduces the amount of code that has to be `unsafeCoerce`d down to just the `unsafeSNat` and `unsafeSSymbol` functions, which I have added to `Data.Constraint.Unsafe`. (If https://gitlab.haskell.org/ghc/ghc/-/issues/23478 were implemented, then we could do away with even those uses of `unsafeCoerce`.)

Fixes #114.