### PR TITLE
Add `Data.Constraint.Char`

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -7,9 +7,12 @@
 * Add `c => Boring (Dict c)` instance
 * Remove `Lifting` instances for `ErrorT` and `ListT`, which were removed
   in `transformers-0.6.*`.
+* Add the `Data.Constraint.Char` module, which contains utilities for working
+  with `KnownChar` constraints. This module is only available on GHC 9.2 or
+  later.
 * Add `unsafeAxiom` to `Data.Constraint.Unsafe`.
-* Add `unsafeSNat` and `unsafeSSymbol` to `Data.Constraint.Unsafe` when building
-  with `base-4.18` (GHC 9.6) or later.
+* Add `unsafeSChar`, `unsafeSNat`, and `unsafeSSymbol` to
+  `Data.Constraint.Unsafe` when building with `base-4.18` (GHC 9.6) or later.
 
 0.13.4 [2022.05.19]
 -------------------

--- a/constraints.cabal
+++ b/constraints.cabal
@@ -70,6 +70,10 @@ library
     Data.Constraint.Symbol
     Data.Constraint.Unsafe
 
+  if impl(ghc >= 9.2)
+    exposed-modules:
+      Data.Constraint.Char
+
   ghc-options: -Wall -Wno-star-is-type
 
 test-suite spec
@@ -78,6 +82,7 @@ test-suite spec
   hs-source-dirs: tests
   main-is: Spec.hs
   other-modules: GH55Spec
+                 GH117Spec
   ghc-options: -Wall -threaded -rtsopts
   build-tool-depends: hspec-discover:hspec-discover >= 2
   build-depends:

--- a/src/Data/Constraint/Char.hs
+++ b/src/Data/Constraint/Char.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE CPP #-}
+-- | Utilities for working with 'KnownChar' constraints.
+--
+-- This module is only available on GHC 9.2 or later.
+module Data.Constraint.Char
+  ( CharToNat
+  , NatToChar
+  , charToNat
+  , natToChar
+  ) where
+
+import Data.Char
+import Data.Constraint
+import Data.Proxy
+import GHC.TypeLits
+#if MIN_VERSION_base(4,18,0)
+import Data.Constraint.Unsafe
+import qualified GHC.TypeNats as TN
+#else
+import Unsafe.Coerce
+#endif
+
+-- implementation details
+
+#if !MIN_VERSION_base(4,18,0)
+newtype Magic c = Magic (KnownChar c => Dict (KnownChar c))
+#endif
+
+magicCN :: forall c n. (Char -> Int) -> KnownChar c :- KnownNat n
+#if MIN_VERSION_base(4,18,0)
+magicCN f = Sub $ TN.withKnownNat (unsafeSNat @n (fromIntegral (f (charVal (Proxy @c))))) Dict
+#else
+magicCN f = Sub $ unsafeCoerce (Magic Dict) (fromIntegral @Int @Natural (f (charVal (Proxy @c))))
+#endif
+
+magicNC :: forall n c. (Int -> Char) -> KnownNat n :- KnownChar c
+#if MIN_VERSION_base(4,18,0)
+magicNC f = Sub $ withKnownChar (unsafeSChar @c (f (fromIntegral (natVal (Proxy @n))))) Dict
+#else
+magicNC f = Sub $ unsafeCoerce (Magic Dict) (f (fromIntegral (natVal (Proxy @n))))
+#endif
+
+-- operations
+
+charToNat :: forall c. KnownChar c :- KnownNat (CharToNat c)
+charToNat = magicCN ord
+
+-- NB: 0x10FFFF the maximum value for a Unicode code point. Calling `chr` on
+-- anything greater will throw an exception.
+natToChar :: forall n. (n <= 0x10FFFF, KnownNat n) :- KnownChar (NatToChar n)
+natToChar = Sub $ case magicNC @n @(NatToChar n) chr of Sub r -> r

--- a/src/Data/Constraint/Unsafe.hs
+++ b/src/Data/Constraint/Unsafe.hs
@@ -28,6 +28,7 @@ module Data.Constraint.Unsafe
 
 #if MIN_VERSION_base(4,18,0)
     -- * Unsafely creating @GHC.TypeLits@ singleton values
+  , unsafeSChar
   , unsafeSNat
   , unsafeSSymbol
 #endif
@@ -38,7 +39,7 @@ import Data.Constraint
 import Unsafe.Coerce
 
 #if MIN_VERSION_base(4,18,0)
-import GHC.TypeLits (SNat, SSymbol)
+import GHC.TypeLits (SChar, SNat, SSymbol)
 import Numeric.Natural (Natural)
 #endif
 
@@ -61,6 +62,21 @@ unsafeUnderive _ = unsafeCoerceConstraint
 #if MIN_VERSION_base(4,18,0)
 -- NB: if https://gitlab.haskell.org/ghc/ghc/-/issues/23478 were implemented,
 -- then we could avoid using 'unsafeCoerce' in the definitions below.
+
+-- | Unsafely create an 'SChar' value directly from a 'Char'. Use this function
+-- with care:
+--
+-- * The 'Char' value must match the 'Char' @c@ encoded in the return type
+--   @'SChar' c@.
+--
+-- * Be wary of using this function to create multiple values of type
+--   @'SChar' T@, where @T@ is a type family that does not reduce (e.g.,
+--   @Any@ from "GHC.Exts"). If you do, GHC is liable to optimize away one of
+--   the values and replace it with the other during a common subexpression
+--   elimination pass. If the two values have different underlying 'Char'
+--   values, this could be disastrous.
+unsafeSChar :: Char -> SChar c
+unsafeSChar = unsafeCoerce
 
 -- | Unsafely create an 'SNat' value directly from a 'Natural'. Use this
 -- function with care:

--- a/tests/GH117Spec.hs
+++ b/tests/GH117Spec.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module GH117Spec (main, spec) where
+
+import Test.Hspec
+
+#if __GLASGOW_HASKELL__ >= 902
+import Data.Constraint
+import Data.Constraint.Char
+import Data.Proxy
+import GHC.TypeLits
+
+spec :: Spec
+spec =
+  describe "GH #117" $ do
+    it "should evaluate `charToNat @'a'` to 97" $
+      case charToNat @'a' of
+        Sub (Dict :: Dict (KnownNat n)) ->
+          natVal (Proxy @n) `shouldBe` 97
+    it "should evaluate `natToChar @97` to 'a'" $
+      case natToChar @97 of
+        Sub (Dict :: Dict (KnownChar c)) ->
+          charVal (Proxy @c) `shouldBe` 'a'
+#else
+spec :: Spec
+spec = return ()
+#endif
+
+main :: IO ()
+main = hspec spec


### PR DESCRIPTION
For now, this module only provides `charToNat` and `natToChar` operations, but we may include more operations in the future.

Fixes #117.