### PR TITLE
Use ghc-bignum for ghc >9.15

### DIFF
--- a/constraints.cabal
+++ b/constraints.cabal
@@ -62,7 +62,10 @@ library
     , hashable       >= 1.2   && < 1.6
     , mtl            >= 2.2   && < 2.4
     , transformers   >= 0.5   && < 0.7
-  if !impl(ghc >= 9.0)
+  if impl(ghc >= 9.15)
+    build-depends:
+      ghc-bignum
+  elif impl(ghc < 9.0)
     build-depends:
       integer-gmp
 


### PR DESCRIPTION
We depend on GHC.Num.Natural. This file was re-exported from base but is part of GHC's internal bignum implementation. We are now only exposing it from ghc-bignum and ghc-internal, so let's get it from there